### PR TITLE
Non zero status on error

### DIFF
--- a/Sources/Docopt/DocoptError.swift
+++ b/Sources/Docopt/DocoptError.swift
@@ -9,6 +9,8 @@
 import Foundation
 
 internal class DocoptError {
+    static let errorStatusCode: Int32 = 1000
+    
     var message: String
     var name: String
    
@@ -26,7 +28,7 @@ internal class DocoptError {
             DocoptError.errorMessage = msg
         } else {
             print(msg)
-            exit(0)
+            exit(DocoptError.errorStatusCode)
         }
     }
 }

--- a/Sources/Docopt/DocoptError.swift
+++ b/Sources/Docopt/DocoptError.swift
@@ -8,18 +8,24 @@
 
 import Foundation
 
+enum DocoptStatus: Int32 {
+    case unknownError = 0x1000
+    case languageError = 0x1001
+    case incorrectArguments = 0x1002
+}
+
 internal class DocoptError {
-    static let errorStatusCode: Int32 = 1000
-    
     var message: String
     var name: String
-   
+    var status: DocoptStatus
+    
     static var test: Bool = false
     static var errorMessage: String?
     
-    init (_ message: String, name: String) {
+    init (_ message: String, name: String, status: DocoptStatus = .unknownError) {
         self.message = message
         self.name = name
+        self.status = status
     }
     
     func raise(_ message: String? = nil) {
@@ -28,21 +34,21 @@ internal class DocoptError {
             DocoptError.errorMessage = msg
         } else {
             print(msg)
-            exit(DocoptError.errorStatusCode)
+            exit(status.rawValue)
         }
     }
 }
 
 internal class DocoptLanguageError: DocoptError {
     init (_ message: String = "Error in construction of usage-message by developer.") {
-        super.init(message, name: "DocoptLanguageError")
+        super.init(message, name: "DocoptLanguageError", status: .languageError)
     }
 }
 
 internal class DocoptExit: DocoptError {
     static var usage: String = ""
     init (_ message: String = "Exit in case user invoked program with incorrect arguments.") {
-        super.init(message, name: "DocoptExit")
+        super.init(message, name: "DocoptExit", status: .incorrectArguments)
     }
 
     override func raise(_ message: String? = nil) {


### PR DESCRIPTION
If docopt calls `exit()` in an error situation, it currently always calls `exit(0)`. 

Doing this makes life difficult for command-line tools that want to use docopt, but want the status code of 0 to actually mean that things worked ok.

In an ideal world, docopt should probably not call exit itself, instead it should throw an error (or call a user-replaceable function).

In this non-ideal world, I've changed docopt to return a non-zero status code. The choice of codes is fairly arbitrary and might clash with a tool (which is why it's non-ideal), but this is better than always returning 0.